### PR TITLE
feat: Make BikeAdvisor component fill parent container

### DIFF
--- a/bike-advisor.tsx
+++ b/bike-advisor.tsx
@@ -570,7 +570,7 @@ const EBikeAdvisor = () => {
   };
   
   return (
-    <div className="min-h-screen bg-white py-8">
+    <div className="h-full w-full bg-white py-8 flex flex-col">
       <header className="max-w-6xl mx-auto mb-8 px-4">
         <h1 className="text-3xl font-bold">EVO Sykkelrådgivning</h1>
         <p className="text-gray-600 mt-2">
@@ -578,7 +578,7 @@ const EBikeAdvisor = () => {
         </p>
       </header>
       
-      <div className="max-w-6xl mx-auto px-4">
+      <div className="max-w-6xl mx-auto px-4 flex-grow overflow-y-auto">
         {!showRecommendations ? (
           <>
             {renderSentence()}


### PR DESCRIPTION
Modified the EBikeAdvisor component to utilize the full height and width of its parent container.

Changes:
- The main div of the component now uses `h-full w-full flex flex-col`.
- The inner content wrapper div now uses `flex-grow overflow-y-auto` to ensure it expands to fill available space and scrolls when content overflows.

This allows the component to integrate more seamlessly when embedded in a webpage, appearing as part of the page rather than a fixed-size block.